### PR TITLE
Add unit test for formatTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,12 @@ yes, it's art.
 ## Blog Posts
 
 ...
+
+## Running Tests
+
+Execute the PHPUnit suite from the project root:
+
+```bash
+phpunit
+```
    

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Framework Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,28 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/functions.php';
+
+class FunctionsTest extends TestCase
+{
+    public static function titleProvider()
+    {
+        return [
+            ['Hello World', 'hello-world'],
+            ['  Trim Spaces  ', 'trim-spaces'],
+            ['Multiple   Spaces', 'multiple---spaces'],
+            ['Mixed CASE', 'mixed-case'],
+            ['Special_chars!', 'special_chars!'],
+            ['', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider titleProvider
+     */
+    public function testFormatTitle($input, $expected)
+    {
+        $this->assertSame($expected, formatTitle($input));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PHP unit test for `formatTitle`
- configure `phpunit.xml`
- document how to run the tests

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f620cb1588324a6c11c42cdcf4142