### PR TITLE
Fix redirect headers to use absolute URLs

### DIFF
--- a/admin/admin_dashboard.php
+++ b/admin/admin_dashboard.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/admin_login.php
+++ b/admin/admin_login.php
@@ -21,7 +21,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         if (password_verify($password, $hashed_password)) {
             // Password is correct
             $_SESSION["admin_username"] = $username;
-            header("Location: admin_dashboard.php"); // Redirect to the admin dashboard
+            header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_dashboard.php"); // Redirect to the admin dashboard
             exit();
         } else {
             // Password is incorrect

--- a/admin/create_blog.php
+++ b/admin/create_blog.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 
@@ -55,7 +55,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
 
     // Redirect to the same page with the response as a query parameter
-    header("Location: $_SERVER['HTTP_HOST']."/i/admin/manage_blog_posts_update.php?" . http_build_query($response));
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/i/admin/manage_blog_posts_update.php?" . http_build_query($response));
 }
 
 ?>

--- a/admin/create_card.php
+++ b/admin/create_card.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/delete_blog.php
+++ b/admin/delete_blog.php
@@ -5,7 +5,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/delete_card.php
+++ b/admin/delete_card.php
@@ -5,7 +5,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/delete_image.php
+++ b/admin/delete_image.php
@@ -5,7 +5,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,4 +1,4 @@
 <?php
-header("Location: $_SERVER['HTTP_HOST']."/framework/admin/admin_login.php");
+header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
 die();
 ?>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -5,6 +5,6 @@ session_start(); // Start a session to manage user login status
 session_destroy();
 
 // Redirect to the login page
-header("Location: admin_login.php");
+header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
 exit(); // Stop script execution
 ?>

--- a/admin/manage_blog_posts.php
+++ b/admin/manage_blog_posts.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/manage_blog_posts_update.php
+++ b/admin/manage_blog_posts_update.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/manage_cards.php
+++ b/admin/manage_cards.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/manage_images.php
+++ b/admin/manage_images.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 
@@ -13,7 +13,7 @@ include("../includes/db.php");
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/process_image_upload.php
+++ b/admin/process_image_upload.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/process_update_blog.php
+++ b/admin/process_update_blog.php
@@ -4,7 +4,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 
@@ -55,6 +55,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
 
     // Redirect to the same page with the response as a query parameter
-    header("Location: $_SERVER['HTTP_HOST']."/i/admin/manage_blog_posts_update.php?" . http_build_query($response));
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/i/admin/manage_blog_posts_update.php?" . http_build_query($response));
 }
 ?>

--- a/admin/process_update_card.php
+++ b/admin/process_update_card.php
@@ -5,7 +5,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/admin/set_psw.php
+++ b/admin/set_psw.php
@@ -5,7 +5,7 @@ session_start(); // Start a session to manage user login status
 // Check if the administrator is logged in
 if (!isset($_SESSION["admin_username"])) {
     // Redirect to the login page if not logged in
-    header("Location: admin_login.php");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/framework/admin/admin_login.php");
     exit(); // Stop script execution
 }
 

--- a/works.php
+++ b/works.php
@@ -11,7 +11,7 @@ include("includes/functions.php");
 if (isset($_GET['title'])) {
     $title = $_GET['title'];
 } else {
-    header("Location: /i/works/home");
+    header("Location: https://" . $_SERVER['HTTP_HOST'] . "/i/works/home");
     exit;
 }
 // Sanitize the title (assuming it contains only alphanumeric and hyphen characters)


### PR DESCRIPTION
## Summary
- update all redirect headers to use absolute URLs with `https://` protocol

## Testing
- `php -l admin/admin_dashboard.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f6206b9c883249949f973329bbb53